### PR TITLE
Add bin scripts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+SOME_ENV_VAR=some_value

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# env files
+.env
+.envrc

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "foreman"
   gem "listen", "~> 3.2"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     faker (2.12.0)
       i18n (>= 1.6, < 2)
     ffi (1.13.1)
+    foreman (0.87.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.5)
@@ -264,6 +265,7 @@ DEPENDENCIES
   database_cleaner-active_record
   factory_bot_rails
   faker
+  foreman
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+webpack: ./bin/webpack-dev-server

--- a/bin/functions
+++ b/bin/functions
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+BLUE='\033[1;34m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;99m'
+RED='\033[1;91m'
+RESET='\033[0m'
+
+pp() {
+  printf "$1[$2]: $3${RESET}\n"
+}
+
+pp_info() {
+  pp $BLUE "$1" "$2"
+}
+
+pp_success() {
+  pp $GREEN "$1" "$2"
+}
+
+pp_error() {
+  pp $RED "$1" "$2"
+}
+
+pp_warn() {
+  pp $YELLOW "$1" "$2"
+}
+
+not_installed() {
+  [ ! -x "$(command -v "$@")" ]
+}
+
+ensure_confirmation() {
+  read -r "confirmation?please confirm you want to continue [y/n] (default: y)"
+  confirmation=${confirmation:-"y"}
+
+  if [ "$confirmation" != "y" ]; then
+    exit 1
+  fi
+}

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bundle exec foreman start -f Procfile.dev

--- a/bin/setup
+++ b/bin/setup
@@ -1,36 +1,51 @@
-#!/usr/bin/env ruby
-require 'fileutils'
+#!/usr/bin/env bash
 
-# path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+set -e
+source "./bin/functions"
 
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
-end
+pp_info "setup" "Setting up .env file"
+cp .env.sample .env
 
-FileUtils.chdir APP_ROOT do
-  # This script is a way to setup or update your development environment automatically.
-  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
-  # Add necessary setup steps to this file.
+pp_info "setup" "Installing required languages"
+if not_installed "asdf"; then
+  pp_warn "setup" "
+    We are using asdf (https://github.com/asdf-vm/asdf) to manage tool
+    dependencies, since it was not found on your system we cannot ensure that you
+    are using the correct versions of all the tools. Please install it and run
+    this script again, or proceed at your own peril.
+  "
+else
+  set +e
+  asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git 2>/dev/null
+  asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git 2>/dev/null
+  set -e
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  asdf install
 
-  # Install JavaScript dependencies
-  # system('bin/yarn')
+  pp_info "setup" "Installing bundler"
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  gem install bundler
+fi
 
-  puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+if not_installed "yarn"; then
+  pp_error "error" "yarn was not detected on this system, you need it to install frontend dependencies"
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  exit -1
+fi
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
-end
+pp_info "setup" "Installing dependencies with bundler and yarn"
+bundle check || bundle install
+yarn
+
+pp_info "setup" "preparing databases"
+bundle exec rake db:create || true
+bundle exec rake db:migrate
+bundle exec rake db:test:prepare
+
+
+pp_info "setup" "checking chromedriver"
+if not_installed "chromedriver"; then
+  pp_warn "warn" "chromedriver was not detected on this system. It is required to run feature specs, please install it."
+fi
+
+pp_info "setup" "You're good to go. Run bin/server to get the app running."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 0) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
+
 end


### PR DESCRIPTION
Add bin scripts for setup and development.

```
bin/setup
bin/server
```

Bin scripts are a good way of enforcing that a project is already on a deployable and usable state. Every project on the Cooperativa/SV Universe needs to have bin scripts that setup the project and run it's development server. This is imperative as often one of the excuses given by people to NOT contribute to some projects is the required setup process that is not documented. In this case, all is put into a script.

I also added `foreman` which allows you to run Procfiles locally. Why? Because I want to run the `web` process together with `webpack-dev-server` which compiles Javascript assets (will be needed in the future? maybe)

Instead of running `rails server` please use `bin/server` and open the website at `localhost:5000`.

Any questions let me know.