### PR TITLE
Add bot name env var

### DIFF
--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -42,4 +42,15 @@ RSpec.feature "Authentication", js: true do
     expect(page).to have_current_path(login_path)
     expect(page).to have_content("Incorrect email/password")
   end
+
+  it "logs out the user" do
+    user = create(:user)
+    login_user(user)
+
+    visit root_path
+    click_on("Log Out")
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_content("Log In")
+  end
 end


### PR DESCRIPTION
This PR changes the bot name to an environment variable so that we are able to change it, since we won't be using "Bookclub-bot" as a name. 
