### PR TITLE
Enforce login and moderator status to edit data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,10 @@ class ApplicationController < ActionController::Base
   def not_authenticated
     redirect_to login_path
   end
+
+  def require_moderator
+    return if current_user&.moderator
+
+    head :unauthorized
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,6 @@
 class BooksController < ApplicationController
   before_action :require_login, only: %i[new create edit update destroy]
+  before_action :require_moderator, only: %i[new create edit update destroy]
   protect_from_forgery except: :show
 
   def index
@@ -20,10 +21,6 @@ class BooksController < ApplicationController
     @book = Book.new(title: params[:title], author: params[:author])
   end
 
-  def edit
-    @book = Book.find(params[:id])
-  end
-
   def create
     create_book = CreateBookFromTitleAndAuthor.new(params[:book])
     create_book.perform
@@ -35,6 +32,10 @@ class BooksController < ApplicationController
       flash[:notice] = create_book.reason_for_failure
       redirect_to new_book_path
     end
+  end
+
+  def edit
+    @book = Book.find(params[:id])
   end
 
   def update

--- a/app/controllers/gatherings/notifications_controller.rb
+++ b/app/controllers/gatherings/notifications_controller.rb
@@ -1,4 +1,5 @@
 class Gatherings::NotificationsController < ApplicationController
+  before_action :require_login
   before_action :require_moderator
 
   def create
@@ -7,13 +8,5 @@ class Gatherings::NotificationsController < ApplicationController
     SlackNotifier.notify_minute(@gathering.date, gatherings_url)
 
     redirect_to gatherings_path, notice: "Notification was succesfully sent"
-  end
-
-  private
-
-  def require_moderator
-    return if current_user&.moderator
-
-    head :unauthorized
   end
 end

--- a/app/controllers/gatherings_controller.rb
+++ b/app/controllers/gatherings_controller.rb
@@ -1,6 +1,6 @@
 class GatheringsController < ApplicationController
-  before_action :require_login, only: %i[edit update]
-  before_action :require_moderator, only: %i[new create destroy]
+  before_action :require_login, only: %i[new create edit update destroy]
+  before_action :require_moderator, only: %i[new create edit update destroy]
 
   def index
     @gatherings = Gathering.group_by_year
@@ -57,11 +57,5 @@ class GatheringsController < ApplicationController
       permit(:date, :special_presentation,
              book_presentations_attributes: %i[_destroy id gathering_id
                                                user_id book_id special])
-  end
-
-  def require_moderator
-    return if current_user&.moderator
-
-    head :unauthorized
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     password_confirmation { "foobar" }
     moderator { false }
 
-    trait(:is_moderator) { moderator { true } }
+    trait(:moderator) { moderator { true } }
   end
 end

--- a/spec/features/gathering_spec.rb
+++ b/spec/features/gathering_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Gathering", js: true do
   it "displays a book presentation form when the button is clicked" do
-    login_user(create(:user, :is_moderator))
+    login_user(create(:user, :moderator))
 
     visit new_gathering_path
     click_on("Add Presentation")
@@ -10,8 +10,8 @@ RSpec.feature "Gathering", js: true do
     expect(page).to have_css(".SlimSelect")
   end
 
-  it "displays the Gathering information when editing" do
-    login_user(create(:user))
+  it "displays it's information when editing" do
+    login_user(create(:user, :moderator))
     gathering = create(:gathering_with_book_presentations, :has_special_presentation)
 
     visit(edit_gathering_path(gathering))
@@ -21,7 +21,7 @@ RSpec.feature "Gathering", js: true do
   end
 
   it "creates a gathering" do
-    login_user(create(:user, :is_moderator))
+    login_user(create(:user, :moderator))
     allow(SlackNotifier).to receive(:notify_minute).and_return(nil)
 
     visit(new_gathering_path)
@@ -43,7 +43,7 @@ RSpec.feature "Gathering", js: true do
   end
 
   it "shows the notification button to moderators" do
-    login_user(create(:user, :is_moderator))
+    login_user(create(:user, :moderator))
     gathering = create(:gathering_with_book_presentations, :has_special_presentation)
 
     visit gatherings_path

--- a/spec/requests/books_request_spec.rb
+++ b/spec/requests/books_request_spec.rb
@@ -4,21 +4,39 @@ require "active_support/core_ext/string/filters"
 RSpec.describe "Books", type: :request do
   include ActionView::Helpers::SanitizeHelper
 
-  describe "POST #create", :vcr do
-    before(:all) do
-      login_user(create(:user))
+  describe "GET #new" do
+    it "non-logged users are redirected to login page" do
+      get new_book_path
+
+      expect(Book.count).to eq(0)
+      expect(response).to redirect_to(login_path)
     end
 
+    it "non-moderators are redirected to login page" do
+      login_user(create(:user))
+
+      get new_book_path
+
+      expect(Book.count).to eq(0)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST #create", :vcr do
     it "redirects to books_path on a successful creation" do
-      post books_path, params: { book: { title: "hard boiled wonderland and the end of the world" } }
+      login_user(create(:user, :moderator))
+
+      post books_path, params: {
+        book: { title: "hard boiled wonderland and the end of the world" }
+      }
 
       expect(response).to redirect_to(books_path)
     end
 
     it "creates a book with the correct params" do
+      login_user(create(:user, :moderator))
       expected_image = "http://books.google.com/books/content?id=3ZgKkumhAywC&printsec"\
                           "=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-
       expected_description = "A narrative particle accelerator that zooms between Wild Turkey Whiskey and Bob Dylan,"\
                             " unicorn skulls and voracious librarians, John Coltrane and Lord Jim. Science fiction, "\
                             "detective story and post-modern manifesto all rolled into one rip-roaring novel,"\
@@ -37,19 +55,95 @@ RSpec.describe "Books", type: :request do
     end
 
     it "redirects to new if params are invalid" do
+      login_user(create(:user, :moderator))
+
       post books_path, params: { book: { title: "" } }
 
       expect(Book.last).to be_falsy
       expect(response).to redirect_to(new_book_path)
     end
+
+    it "non-logged users are redirected to login page" do
+      post books_path, params: {
+        book: { title: "hard boiled wonderland and the end of the world" }
+      }
+
+      expect(Book.count).to eq(0)
+      expect(response).to redirect_to(login_path)
+    end
+
+    it "non-moderators are redirected to login page" do
+      login_user(create(:user))
+
+      post books_path, params: {
+        book: { title: "hard boiled wonderland and the end of the world" }
+      }
+
+      expect(Book.count).to eq(0)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET #edit" do
+    it "non-logged users are redirected to login page" do
+      book = create(:book)
+
+      get edit_book_path(book)
+
+      expect(response).to redirect_to(login_path)
+    end
+
+    it "non-moderators are redirected to login page" do
+      login_user(create(:user))
+      book = create(:book)
+
+      get edit_book_path(book)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "PUT #update" do
+    it "updates a book successfully" do
+      login_user(create(:user, :moderator))
+      book = create(:book)
+      new_book_params = attributes_for(:book)
+
+      put book_path(book), params: { book: new_book_params }
+      book.reload
+
+      expect(book.title).to eq(new_book_params[:title])
+      expect(book.author).to eq(new_book_params[:author])
+      expect(book.image).to eq(new_book_params[:image])
+      expect(book.synopsis).to eq(new_book_params[:synopsis])
+      expect(response).to redirect_to(books_path)
+    end
+
+    it "non-logged users are redirected to login page" do
+      book = create(:book)
+      new_book_params = attributes_for(:book)
+
+      put book_path(book), params: { book: new_book_params }
+
+      expect(Book.last).to eq(book)
+      expect(response).to redirect_to(login_path)
+    end
+
+    it "non-moderators are redirected to login page" do
+      login_user(create(:user))
+      book = create(:book)
+      new_book_params = attributes_for(:book)
+
+      put book_path(book), params: { book: new_book_params }
+
+      expect(Book.last).to eq(book)
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   describe "DELETE #destroy" do
-    before(:all) do
-      login_user(create(:user))
-    end
-
     it "redirects to books_path on a successful delete" do
+      login_user(create(:user, :moderator))
       book = create(:book)
 
       delete book_path(book)
@@ -58,11 +152,31 @@ RSpec.describe "Books", type: :request do
     end
 
     it "destroys a book" do
+      login_user(create(:user, :moderator))
       book = create(:book)
 
       delete book_path(book)
 
       expect(Book.count).to eq(0)
+    end
+
+    it "non-logged users are redirected to login page" do
+      book = create(:book)
+
+      delete book_path(book)
+
+      expect(Book.count).to eq(1)
+      expect(response).to redirect_to(login_path)
+    end
+
+    it "non-moderators are redirected to login page" do
+      login_user(create(:user))
+      book = create(:book)
+
+      delete book_path(book)
+
+      expect(Book.count).to eq(1)
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/requests/notifications_requests_spec.rb
+++ b/spec/requests/notifications_requests_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Notifications", type: :request do
   describe "POST #create" do
+    it "non-logged users are redirected to login page" do
+      gathering = create(:gathering)
+
+      post gathering_notifications_path(gathering), params: { gathering_id: gathering.id }
+
+      expect(response).to redirect_to(login_path)
+    end
+
     it "returns unauthorized if user is not moderator" do
       login_user(create(:user))
       gathering = create(:gathering)
@@ -13,7 +21,7 @@ RSpec.describe "Notifications", type: :request do
 
     it "redirects to gatherings_path on a successful notification" do
       allow(SlackNotifier).to receive(:notify_minute).and_return(nil)
-      login_user(create(:user, :is_moderator))
+      login_user(create(:user, :moderator))
       gathering = create(:gathering)
 
       post gathering_notifications_path(gathering), params: { gathering_id: gathering.id }


### PR DESCRIPTION
To prevent people from messing up the existing data, only moderators should be able to edit data.