### PR TITLE
Fix empty links

### DIFF
--- a/app/views/book_presentations/_book_presentation_hash.html.erb
+++ b/app/views/book_presentations/_book_presentation_hash.html.erb
@@ -3,7 +3,7 @@
     <ul>
       <li>
         <%= link_to book_presentations[0].user.name,
-              books_path(:user_id => user_id),
+              user_books_path(:user_id => user_id),
               class: "text-blue-500 font-semibold hover:underline",
               data: { "turbo-frame": "_top" }
         %>

--- a/app/views/books/_book_list.erb
+++ b/app/views/books/_book_list.erb
@@ -33,14 +33,14 @@
             <% if book.users.length <= 3 %>
               <% book.users.each_with_index do |user, index| %>
                 <%= link_to user.name,
-                      books_path(:user_id => user.id),
+                      user_books_path(:user_id => user.id),
                       class: "font-semibold hover:underline" %>
                 <% if index < book.users.count - 1 %>,<% end %>
               <% end %>
             <% else %>
               <% book.users[0..2].each_with_index do |user, index| %>
                 <%= link_to user.name,
-                      books_path(:user_id => user.id),
+                      user_books_path(:user_id => user.id),
                       class: "font-semibold hover:underline" %>
                 <% if index < 2 %>,<% end %>
               <% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -30,6 +30,7 @@
       <turbo-frame
         id="gathering_<%= gathering.id %>_books"
         src="<%= gathering_books_path(gathering, search: @search_param) %>"
+        target="_top"
       ></turbo-frame>
     <% end %>
   <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,7 +25,7 @@
       <ul class="list-disc pl-8">
         <% @presenting_users.each do |user| %>
           <li>
-            <%= link_to user.name, books_path(:user_id => user.id) %>
+            <%= link_to user.name, user_books_path(:user_id => user.id) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/gatherings/books/index.html.erb
+++ b/app/views/gatherings/books/index.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="gathering_<%= @gathering.id %>_books">
+<turbo-frame id="gathering_<%= @gathering.id %>_books" target="_top">
   <%= render "_components/section_title" do %>
     <%= show_date_month(@gathering) %>&nbsp;&nbsp;<%= @gathering.date.year %>
   <% end %>

--- a/app/views/gatherings/index.html.erb
+++ b/app/views/gatherings/index.html.erb
@@ -54,6 +54,7 @@
           id="<%= dom_id(gathering) %>"
           src="/gatherings/<%= gathering.id %>"
           class="block mt-4"
+          target="_top"
         >
           Loading...
         </turbo-frame>

--- a/app/views/gatherings/show.html.erb
+++ b/app/views/gatherings/show.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="<%= dom_id(@gathering) %>">
+<turbo-frame id="<%= dom_id(@gathering) %>" target="_top">
   <div class="flex items-center justify-between pt-4 pb-6 sm:flex-col sm:items-start">
     <h2 class="text-xl text-blue-600 font-sans">Book Mentions</h2>
 
@@ -26,7 +26,6 @@
               class: "sm:mt-4"
             ),
             edit_gathering_path(@gathering),
-            data: { "turbo-frame": "_top" }
         %>
       <% end %>
     </div>

--- a/app/views/gatherings/show.html.erb
+++ b/app/views/gatherings/show.html.erb
@@ -25,7 +25,7 @@
               alt: "edit",
               class: "sm:mt-4"
             ),
-            edit_gathering_path(@gathering),
+            edit_gathering_path(@gathering)
         %>
       <% end %>
     </div>

--- a/app/views/users/books/index.html.erb
+++ b/app/views/users/books/index.html.erb
@@ -16,6 +16,7 @@
       <turbo-frame
         id="gathering_<%= gathering.id %>_books"
         src="<%= gathering_books_path(gathering, user_id: @user.id) %>"
+        target="_top"
       ></turbo-frame>
     <% end %>
   <% end %>


### PR DESCRIPTION
Changes the target of turbo frames so the page navigation is applied to the whole page instead of the single frame.

It also fixes all the instances of "books of X user" links, to use the new route.